### PR TITLE
✨ feat: add `alt` and rename command `clean` to `reset`

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -14,7 +14,7 @@ pub struct Args {
 pub enum Commands {
     Choose(ChooseArgs),
     Setup(SetupArgs),
-    Clean,
+    Reset,
 }
 
 #[derive(Parser, Debug, PartialEq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
         Commands::Setup(args) => {
             setup(args).unwrap();
         }
-        Commands::Clean => {
+        Commands::Reset => {
             clean_dir(&CONFIG_DIR).expect("Could not clean config");
         }
     }

--- a/src/reply.rs
+++ b/src/reply.rs
@@ -16,7 +16,9 @@ fn format_lgtmeow(
 ) -> Reply {
     Reply {
         title: format!("LGTMeow {left_emoji}+{right_emoji}"),
-        content: format!("LGTMeow <img src=\"{kitchen_link}\" width=\"{image_width}\"/>"),
+        content: format!(
+            "LGTMeow <img src=\"{kitchen_link}\" width=\"{image_width}\" alt=\"🐾\"/>"
+        ),
     }
 }
 


### PR DESCRIPTION
- 添加 `alt` 属性，以便就算未来图片显示不出来也能 fallback 回 🐾
- rename 子命令 `clean` 为 `reset`，因为现在已经没有 cache 了