### PR TITLE
👷 ci: pin maturin-version to `1.4.0`

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -31,6 +31,7 @@ jobs:
           args: --release --out dist --find-interpreter
           sccache: "true"
           manylinux: auto
+          maturin-version: "1.4.0"
           # Refer to https://github.com/sfackler/rust-openssl/issues/2036#issuecomment-1724324145
           before-script-linux: |
             # If we're running on rhel centos, install needed packages.
@@ -71,6 +72,7 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter
           sccache: "true"
+          maturin-version: "1.4.0"
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -95,6 +97,7 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist --find-interpreter
           sccache: "true"
+          maturin-version: "1.4.0"
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
@@ -110,6 +113,7 @@ jobs:
         with:
           command: sdist
           args: --out dist
+          maturin-version: "1.4.0"
       - name: Upload sdist
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
暂时回退 maturin 到 1.4.0，新版本 1.5.0 Metadata-Version 升级到 2.3，但貌似 [pypa/gh-action-pypi-publish@release/v1](https://github.com/pypa/gh-action-pypi-publish) 尚不支持 2.3

https://github.com/moefyit/lgtmeow/actions/runs/8150209752/job/22276146422

```
Checking dist/lgtmeow-0.4.0-py3-none-macosx_10_12_x86_64.whl: ERROR    InvalidDistribution: Metadata is missing required fields: Name,        
         Version.                                                               
         Make sure the distribution includes the files where those fields are   
         specified, and is using a supported Metadata-Version: 1.0, 1.1, 1.2,   
         2.0, 2.1, 2.2.
```