### PR TITLE
✨ feat: limit max rows in selection prompts to improve usability

### DIFF
--- a/src/cli/choose.rs
+++ b/src/cli/choose.rs
@@ -30,6 +30,7 @@ pub fn choose(args: ChooseArgs) -> std::io::Result<()> {
                     .map(|(idx, reply)| (idx, reply.title.clone(), "".to_string()))
                     .collect::<Vec<(_, _, _)>>(),
             )
+            .max_rows(10)
             .interact()?;
         selected_reply = &replies[selected_idx];
         cliclack::log::success(&selected_reply.title)?;

--- a/src/cli/setup.rs
+++ b/src/cli/setup.rs
@@ -126,6 +126,7 @@ pub fn setup(args: SetupArgs) -> std::io::Result<()> {
                 cliclack::multiselect("Pick your favorite LGTMeow🐾")
                     .initial_values(paw_prints_cliclack_initial_values)
                     .items(&paw_prints_cliclack_items)
+                    .max_rows(10)
                     .interact()?;
         }
         #[cfg(feature = "emoji-cat")]
@@ -134,6 +135,7 @@ pub fn setup(args: SetupArgs) -> std::io::Result<()> {
                 cliclack::multiselect("Pick your favorite LGTMeow🐱")
                     .initial_values(cat_cliclack_initial_values)
                     .items(&cat_cliclack_items)
+                    .max_rows(10)
                     .interact()?;
         }
 


### PR DESCRIPTION
fadeevab/cliclack#91 总算支持了 `max_rows` 选项，交互式总算变得至少可用了